### PR TITLE
Added support for url-escaped http credentials

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -29,8 +29,8 @@ module Vagrant
         begin
           url = URI.parse(@source)
           if url.scheme && url.scheme.start_with?("http") && url.user
-            auth = "#{url.user}"
-            auth += ":#{url.password}" if url.password
+            auth = "#{URI.unescape(url.user)}"
+            auth += ":#{URI.unescape(url.password)}" if url.password
             url.user = nil
             url.password = nil
             options[:auth] ||= auth

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -72,6 +72,27 @@ describe Vagrant::Util::Downloader do
         expect(subject.download!).to be_true
       end
     end
+    
+    context "with an urlescaped username and password" do
+      it "downloads the file with unescaped credentials" do
+        original_source = source
+        source  = "http://fo%5Eo:b%40r@baz.com/box.box"
+        subject = described_class.new(source, destination)
+
+        i = curl_options.index(original_source)
+        curl_options[i] = "http://baz.com/box.box"
+
+        i = curl_options.index("--output")
+        curl_options.insert(i, "fo^o:b@r")
+        curl_options.insert(i, "-u")
+
+        expect(Vagrant::Util::Subprocess).to receive(:execute).
+          with("curl", *curl_options).
+          and_return(subprocess_result)
+
+        expect(subject.download!).to be_true
+      end
+    end
   end
 
   describe "#head" do


### PR DESCRIPTION
Related to #5567.

When the user or password in a box_url contains special characters, which need to be escaped, then the download did not work, because the credentials are stripped from the url and fed to curl exactly as they are. Curl takes its credentials unescaped.

Sample url to test: http://user:myP%40ssword@server.com/ubuntu.box
